### PR TITLE
Revamp home page with dark Android theme

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -1,0 +1,336 @@
+/* ── Android Dark Theme ─────────────────────────────── */
+
+:root {
+    --android-green: #3DDC84;
+    --android-green-dim: rgba(61, 220, 132, 0.12);
+    --android-green-glow: rgba(61, 220, 132, 0.22);
+}
+
+/* Deep dark palette for dark mode */
+:root[data-theme="dark"] {
+    --theme: #0D1117;
+    --entry: #161B22;
+    --primary: rgba(255, 255, 255, 0.87);
+    --secondary: rgba(255, 255, 255, 0.54);
+    --tertiary: rgba(255, 255, 255, 0.10);
+    --content: rgba(255, 255, 255, 0.80);
+    --hljs-bg: #161B22;
+    --code-bg: #1C2128;
+    --border: rgba(255, 255, 255, 0.07);
+}
+
+/* ── Global accents ─────────────────────────────────── */
+
+.post-content a,
+.entry-content a {
+    color: var(--android-green);
+    text-decoration-color: rgba(61, 220, 132, 0.4);
+}
+
+.post-content a:hover,
+.entry-content a:hover {
+    text-decoration-color: var(--android-green);
+}
+
+.post-tags a:hover {
+    background: var(--android-green-dim);
+    border-color: rgba(61, 220, 132, 0.35);
+    color: var(--android-green);
+}
+
+/* ── Hero section ───────────────────────────────────── */
+
+.android-hero {
+    display: flex;
+    justify-content: center;
+    padding: 56px 20px 44px;
+    text-align: center;
+}
+
+.hero-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    max-width: 540px;
+    width: 100%;
+}
+
+.hero-avatar-wrap {
+    position: relative;
+    width: 110px;
+    height: 110px;
+    flex-shrink: 0;
+}
+
+.hero-avatar {
+    width: 110px;
+    height: 110px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2.5px solid var(--android-green);
+    box-shadow: 0 0 0 4px var(--android-green-dim), 0 0 28px var(--android-green-glow);
+}
+
+.hero-name {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 4px 0 0;
+    letter-spacing: -0.025em;
+    line-height: 1.2;
+}
+
+.hero-role {
+    font-size: 1rem;
+    color: var(--secondary);
+    margin: 0;
+    letter-spacing: 0.01em;
+}
+
+.hero-role-label {
+    color: var(--android-green);
+    font-weight: 600;
+}
+
+.hero-role-sep {
+    opacity: 0.6;
+}
+
+.hero-company {
+    color: var(--secondary);
+    text-decoration: none;
+    transition: color 0.18s;
+}
+
+.hero-company:hover {
+    color: var(--android-green);
+}
+
+.hero-bio {
+    font-size: 0.93rem;
+    color: var(--secondary);
+    line-height: 1.65;
+    margin: 2px 0 0;
+    max-width: 400px;
+}
+
+/* ── Hero buttons ───────────────────────────────────── */
+
+.hero-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 6px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.hero-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 24px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: transform 0.18s, box-shadow 0.18s, background 0.18s, border-color 0.18s;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.hero-btn-primary {
+    background: var(--android-green);
+    color: #0A0F0D;
+    border: 1px solid transparent;
+}
+
+.hero-btn-primary:hover {
+    background: #5AEA9B;
+    color: #0A0F0D;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--android-green-glow);
+}
+
+.hero-btn-secondary {
+    background: transparent;
+    color: var(--android-green);
+    border: 1px solid rgba(61, 220, 132, 0.35);
+}
+
+.hero-btn-secondary:hover {
+    background: var(--android-green-dim);
+    border-color: var(--android-green);
+    transform: translateY(-2px);
+}
+
+/* ── Hero social icons ──────────────────────────────── */
+
+.hero-socials {
+    display: flex;
+    align-items: center;
+    gap: 22px;
+    margin-top: 2px;
+}
+
+.hero-social-link {
+    color: var(--secondary);
+    transition: color 0.18s, transform 0.18s;
+    display: flex;
+}
+
+.hero-social-link:hover {
+    color: var(--android-green);
+    transform: translateY(-2px);
+}
+
+.hero-social-link svg {
+    width: 22px;
+    height: 22px;
+    fill: currentColor;
+}
+
+/* ── Home post cards ────────────────────────────────── */
+
+.home-posts {
+    margin-top: 4px;
+}
+
+.home-posts-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--secondary);
+    margin-bottom: 14px;
+}
+
+.accent-slash {
+    color: var(--android-green);
+    margin-right: 6px;
+    font-weight: 700;
+}
+
+.home-card {
+    position: relative;
+    background: var(--entry);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--android-green);
+    border-radius: 10px;
+    margin-bottom: 10px;
+    transition: border-color 0.2s, transform 0.18s, box-shadow 0.2s;
+    overflow: hidden;
+}
+
+.home-card:hover {
+    border-color: rgba(61, 220, 132, 0.35);
+    border-left-color: var(--android-green);
+    box-shadow: 0 4px 24px rgba(61, 220, 132, 0.07);
+    transform: translateX(4px);
+}
+
+.home-card-inner {
+    display: flex;
+    align-items: center;
+    padding: 18px 20px;
+    gap: 16px;
+}
+
+.home-card-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.home-card-title {
+    font-size: 0.97rem;
+    font-weight: 500;
+    color: var(--primary);
+    margin: 0 0 5px;
+    line-height: 1.4;
+    transition: color 0.18s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.home-card:hover .home-card-title {
+    color: var(--android-green);
+}
+
+.home-card-meta {
+    font-size: 0.78rem;
+    color: var(--secondary);
+}
+
+.home-card-arrow {
+    color: var(--tertiary);
+    flex-shrink: 0;
+    transition: color 0.18s, transform 0.18s;
+    display: flex;
+}
+
+.home-card:hover .home-card-arrow {
+    color: var(--android-green);
+    transform: translateX(3px);
+}
+
+.home-card-link {
+    position: absolute;
+    inset: 0;
+}
+
+/* ── Header nav tweaks ──────────────────────────────── */
+
+.nav {
+    border-bottom: 1px solid var(--border);
+}
+
+/* ── Code blocks ────────────────────────────────────── */
+
+.highlight {
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    overflow: hidden;
+}
+
+/* ── Post page links ────────────────────────────────── */
+
+.post-single .post-content a {
+    color: var(--android-green);
+}
+
+/* ── Responsive ─────────────────────────────────────── */
+
+@media (max-width: 600px) {
+    .android-hero {
+        padding: 36px 16px 28px;
+    }
+
+    .hero-name {
+        font-size: 1.6rem;
+    }
+
+    .hero-avatar {
+        width: 90px;
+        height: 90px;
+    }
+
+    .hero-avatar-wrap {
+        width: 90px;
+        height: 90px;
+    }
+
+    .hero-actions {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .hero-btn {
+        width: 180px;
+        justify-content: center;
+    }
+
+    .home-card-title {
+        white-space: normal;
+    }
+}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -20,7 +20,7 @@ params:
   keywords: [Blog, Android, Kotlin, ]
   images: ["<link or path of image for opengraph, twitter-cards>"]
   DateFormat: "January 2, 2006"
-  defaultTheme: auto
+  defaultTheme: dark
   disableThemeToggle: false
   googleAnalytics: "G-9FX0CB6DDP"
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,13 +1,32 @@
 {{- define "main" }}
 
 {{- if .IsHome }}
-{{- partial "index_profile.html" . }}
-{{- else }} {{/* if not profileMode */}}
-{{- end }}{{/* end profileMode */}}
-
-{{- if .IsHome }}
-<h2 style="margin-bottom: 20px;">Recent Posts</h2>
-{{- end }}{{/* end profileMode */}}
+<div class="android-hero">
+  <div class="hero-inner">
+    <div class="hero-avatar-wrap">
+      <img src="/dp.webp" alt="{{ site.Title }}" class="hero-avatar" width="104" height="104">
+    </div>
+    <h1 class="hero-name">{{ site.Title }}</h1>
+    <p class="hero-role">
+      <span class="hero-role-label">Android</span>
+      <span class="hero-role-sep"> @ </span>
+      <a href="https://www.swiggy.com/" class="hero-company" target="_blank" rel="noopener noreferrer">Swiggy</a>
+    </p>
+    <p class="hero-bio">Building scalable Android apps that deliver food to millions. Writing about mobile engineering, testing &amp; Kotlin.</p>
+    <div class="hero-actions">
+      <a href="/blog/" class="hero-btn hero-btn-primary">Read Blog</a>
+      <a href="https://github.com/anikrajc" class="hero-btn hero-btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+    <div class="hero-socials">
+      {{- range site.Params.socialIcons }}
+      <a href="{{ .url | safeURL }}" title="{{ .name | title }}" target="_blank" rel="noopener noreferrer me" class="hero-social-link">
+        {{- partial "svg.html" . }}
+      </a>
+      {{- end }}
+    </div>
+  </div>
+</div>
+{{- end }}
 
 {{- if not .IsHome | and .Title }}
 <header class="page-header">
@@ -28,16 +47,13 @@
     {{- end }}
   </h1>
   {{- if .Description }}
-  <div class="post-description">
-    {{ .Description | markdownify }}
-  </div>
+  <div class="post-description">{{ .Description | markdownify }}</div>
   {{- end }}
 </header>
 {{- end }}
 
 {{- if .Content }}
 <div class="post-content">
-  <div>Test 1</div>
   {{- if not (.Param "disableAnchoredHeadings") }}
   {{- partial "anchored_headings.html" .Content -}}
   {{- else }}{{ .Content }}{{ end }}
@@ -45,7 +61,6 @@
 {{- end }}
 
 {{- $pages := union .RegularPages .Sections }}
-
 {{- if .IsHome }}
 {{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
 {{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true" }}
@@ -53,71 +68,73 @@
 
 {{- $paginator := .Paginate $pages }}
 
+{{- if and .IsHome (gt (len $paginator.Pages) 0) }}
+<div class="home-posts">
+  <h2 class="home-posts-title"><span class="accent-slash">//</span> Recent Posts</h2>
+{{- end }}
+
 {{- $term := .Data.Term }}
 {{- range $index, $page := $paginator.Pages }}
 
-{{- $class := "post-entry" }}
-
-{{- $user_preferred := or site.Params.disableSpecial1stPost site.Params.homeInfoParams }}
 {{- if $.IsHome }}
-{{- $class = "first-entry" }}
-{{- else if $term }}
-{{- $class = "post-entry tag-entry" }}
-{{- end }}
-
-<article class="{{ $class }}">
-  {{- if not $.IsHome }}
-  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
-  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
-  {{- end }}
-  <div class="post-contents">
-    <header class="entry-header">
-
-      {{- if $.IsHome }}
-      <div class="entry-hint-parents">
-        {{- .Title }}
-        {{- if .Draft }}
+<article class="home-card">
+  <div class="home-card-inner">
+    <div class="home-card-body">
+      <h3 class="home-card-title">
+        {{- $page.Title }}
+        {{- if $page.Draft }}
         <span class="entry-hint" title="Draft">
-          <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
-            <path
-              d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
-          </svg>
-        </span>
-        {{- end }}
-      </div>
-      {{- else }}
-      <h3 class="entry-hint-parent">
-        {{- .Title }}
-        {{- if .Draft }}
-        <span class="entry-hint" title="Draft">
-          <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
-            <path
-              d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
-          </svg>
+          <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 -960 960 960" fill="currentColor"><path d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z"/></svg>
         </span>
         {{- end }}
       </h3>
-      {{- end }}{{/* end profileMode */}}
+      {{- if not ($page.Param "hideMeta") }}
+      <div class="home-card-meta">{{- partial "post_meta.html" $page -}}</div>
+      {{- end }}
+    </div>
+    <div class="home-card-arrow">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M5 12h14M12 5l7 7-7 7"/>
+      </svg>
+    </div>
+  </div>
+  <a class="home-card-link" aria-label="post link to {{ $page.Title | plainify }}" href="{{ $page.Permalink }}"></a>
+</article>
+{{- else }}
 
+{{- $class := "post-entry" }}
+{{- if $term }}{{- $class = "post-entry tag-entry" }}{{- end }}
 
-
-
+<article class="{{ $class }}">
+  {{- $isHidden := ($page.Param "cover.hiddenInList") | default ($page.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" $page "IsSingle" false "isHidden" $isHidden) }}
+  <div class="post-contents">
+    <header class="entry-header">
+      <h3 class="entry-hint-parent">
+        {{- $page.Title }}
+        {{- if $page.Draft }}
+        <span class="entry-hint" title="Draft">
+          <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor"><path d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z"/></svg>
+        </span>
+        {{- end }}
+      </h3>
     </header>
-
-    {{- if (and (not $.IsHome) (ne (.Param "hideSummary") true)) }}
+    {{- if not ($page.Param "hideSummary") }}
     <div class="entry-content">
-      <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+      <p>{{ $page.Summary | plainify | htmlUnescape }}{{ if $page.Truncated }}...{{ end }}</p>
     </div>
     {{- end }}
-
-    {{- if not (.Param "hideMeta") }}
-    <footer class="entry-footer">
-      {{- partial "post_meta.html" . -}}
-    </footer>
+    {{- if not ($page.Param "hideMeta") }}
+    <footer class="entry-footer">{{- partial "post_meta.html" $page -}}</footer>
     {{- end }}
-    <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
-</div>
+    <a class="entry-link" aria-label="post link to {{ $page.Title | plainify }}" href="{{ $page.Permalink }}"></a>
+  </div>
 </article>
+{{- end }}
+{{- end }}
+
+{{- if and .IsHome (gt (len $paginator.Pages) 0) }}
+</div>
 {{- end }}
 
 {{- if gt $paginator.TotalPages 1 }}
@@ -142,6 +159,5 @@
   </nav>
 </footer>
 {{- end }}
-
 
 {{- end }}{{- /* end main */ -}}


### PR DESCRIPTION
Full home page revamp with an Android-branded dark theme.

**Changes:**
- Default theme switched to dark
- New hero section: circular avatar with Android green glow ring, name, "Android @ Swiggy" role label, bio, "Read Blog" + "GitHub" CTA buttons, social icon row
- Home page post list replaced with sleek cards featuring an Android green left-border accent, animated arrow, and slide-on-hover effect
- New `android-theme.css`: deep `#0D1117` dark palette, `#3DDC84` Android green accents throughout (links, buttons, borders, glow effects), fully responsive

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_