### PR TITLE
Retheme: btop-inspired terminal aesthetic

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -1,336 +1,501 @@
-/* ── Android Dark Theme ─────────────────────────────── */
+/* ── btop-inspired Terminal Theme ──────────────────────── */
 
+/* Color tokens — palette from btop default theme */
 :root {
-    --android-green: #3DDC84;
-    --android-green-dim: rgba(61, 220, 132, 0.12);
-    --android-green-glow: rgba(61, 220, 132, 0.22);
+    --t-bg:          #0A0A0A;
+    --t-panel:       #0D1710;
+    --t-panel-alt:   #101A13;
+    --t-border:      #00E5A0;
+    --t-border-dim:  rgba(0, 229, 160, 0.20);
+    --t-border-faint:rgba(0, 229, 160, 0.08);
+    --t-green:       #00E5A0;
+    --t-green-lit:   #3DD57D;
+    --t-green-dim:   rgba(0, 229, 160, 0.10);
+    --t-cyan:        #29DFFF;
+    --t-orange:      #FFAA00;
+    --t-text:        #DDEEDD;
+    --t-text-dim:    #B0C4BC;
+    --t-muted:       #4D7260;
+    --t-sep:         #2A4A3A;
+
+    /* Override PaperMod vars to match terminal palette */
+    --theme:         #0A0A0A;
+    --entry:         #0D1710;
+    --primary:       #DDEEDD;
+    --secondary:     #7A9A8A;
+    --tertiary:      rgba(0, 229, 160, 0.07);
+    --content:       #C8DCD0;
+    --hljs-bg:       #0D1710;
+    --code-bg:       #111C14;
+    --border:        rgba(0, 229, 160, 0.14);
+    --radius:        2px;
 }
 
-/* Deep dark palette for dark mode */
 :root[data-theme="dark"] {
-    --theme: #0D1117;
-    --entry: #161B22;
-    --primary: rgba(255, 255, 255, 0.87);
-    --secondary: rgba(255, 255, 255, 0.54);
-    --tertiary: rgba(255, 255, 255, 0.10);
-    --content: rgba(255, 255, 255, 0.80);
-    --hljs-bg: #161B22;
-    --code-bg: #1C2128;
-    --border: rgba(255, 255, 255, 0.07);
+    --theme:         #0A0A0A;
+    --entry:         #0D1710;
+    --primary:       #DDEEDD;
+    --secondary:     #7A9A8A;
+    --tertiary:      rgba(0, 229, 160, 0.07);
+    --content:       #C8DCD0;
+    --hljs-bg:       #0D1710;
+    --code-bg:       #111C14;
+    --border:        rgba(0, 229, 160, 0.14);
 }
 
-/* ── Global accents ─────────────────────────────────── */
+/* ── Base ───────────────────────────────────────────────── */
 
-.post-content a,
-.entry-content a {
-    color: var(--android-green);
-    text-decoration-color: rgba(61, 220, 132, 0.4);
+html, body {
+    background-color: var(--t-bg) !important;
 }
 
-.post-content a:hover,
-.entry-content a:hover {
-    text-decoration-color: var(--android-green);
+/* ── Header ─────────────────────────────────────────────── */
+
+.header {
+    background: var(--t-bg) !important;
+    border-bottom: 1px solid var(--t-border-dim) !important;
 }
 
-.post-tags a:hover {
-    background: var(--android-green-dim);
-    border-color: rgba(61, 220, 132, 0.35);
-    color: var(--android-green);
-}
-
-/* ── Hero section ───────────────────────────────────── */
-
-.android-hero {
-    display: flex;
-    justify-content: center;
-    padding: 56px 20px 44px;
-    text-align: center;
-}
-
-.hero-inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 14px;
-    max-width: 540px;
-    width: 100%;
-}
-
-.hero-avatar-wrap {
-    position: relative;
-    width: 110px;
-    height: 110px;
-    flex-shrink: 0;
-}
-
-.hero-avatar {
-    width: 110px;
-    height: 110px;
-    border-radius: 50%;
-    object-fit: cover;
-    border: 2.5px solid var(--android-green);
-    box-shadow: 0 0 0 4px var(--android-green-dim), 0 0 28px var(--android-green-glow);
-}
-
-.hero-name {
-    font-size: 2rem;
+.logo a {
+    color: var(--t-green) !important;
     font-weight: 700;
-    color: var(--primary);
-    margin: 4px 0 0;
-    letter-spacing: -0.025em;
-    line-height: 1.2;
+    letter-spacing: -0.01em;
+    text-decoration: none !important;
 }
 
-.hero-role {
-    font-size: 1rem;
-    color: var(--secondary);
-    margin: 0;
-    letter-spacing: 0.01em;
+.logo a::before {
+    content: "$ ";
+    color: var(--t-muted);
+    font-weight: 400;
 }
 
-.hero-role-label {
-    color: var(--android-green);
-    font-weight: 600;
+#menu li a {
+    color: var(--t-muted) !important;
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-decoration: none !important;
+    transition: color 0.15s;
 }
 
-.hero-role-sep {
-    opacity: 0.6;
+#menu li a::before { content: "[ "; color: var(--t-sep); }
+#menu li a::after  { content: " ]"; color: var(--t-sep); }
+
+#menu li a:hover,
+#menu li a span.active {
+    color: var(--t-green) !important;
 }
 
-.hero-company {
-    color: var(--secondary);
-    text-decoration: none;
-    transition: color 0.18s;
+#menu li a:hover::before,
+#menu li a:hover::after {
+    color: var(--t-border-dim);
 }
 
-.hero-company:hover {
-    color: var(--android-green);
+/* theme toggle icon color */
+#theme-toggle {
+    color: var(--t-muted) !important;
 }
 
-.hero-bio {
-    font-size: 0.93rem;
-    color: var(--secondary);
-    line-height: 1.65;
-    margin: 2px 0 0;
-    max-width: 400px;
+#theme-toggle:hover {
+    color: var(--t-green) !important;
 }
 
-/* ── Hero buttons ───────────────────────────────────── */
+/* ── Terminal panel widget ──────────────────────────────── */
 
-.hero-actions {
-    display: flex;
-    gap: 12px;
-    margin-top: 6px;
-    flex-wrap: wrap;
-    justify-content: center;
+.term-panel {
+    position: relative;
+    border: 1px solid var(--t-border-dim);
+    border-radius: var(--radius);
+    background: var(--t-panel);
+    padding: 22px 18px 18px;
+    transition: border-color 0.2s;
 }
 
-.hero-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 24px;
-    border-radius: 8px;
-    font-size: 0.9rem;
-    font-weight: 500;
-    text-decoration: none;
-    transition: transform 0.18s, box-shadow 0.18s, background 0.18s, border-color 0.18s;
-    cursor: pointer;
-    white-space: nowrap;
-}
-
-.hero-btn-primary {
-    background: var(--android-green);
-    color: #0A0F0D;
-    border: 1px solid transparent;
-}
-
-.hero-btn-primary:hover {
-    background: #5AEA9B;
-    color: #0A0F0D;
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px var(--android-green-glow);
-}
-
-.hero-btn-secondary {
-    background: transparent;
-    color: var(--android-green);
-    border: 1px solid rgba(61, 220, 132, 0.35);
-}
-
-.hero-btn-secondary:hover {
-    background: var(--android-green-dim);
-    border-color: var(--android-green);
-    transform: translateY(-2px);
-}
-
-/* ── Hero social icons ──────────────────────────────── */
-
-.hero-socials {
-    display: flex;
-    align-items: center;
-    gap: 22px;
-    margin-top: 2px;
-}
-
-.hero-social-link {
-    color: var(--secondary);
-    transition: color 0.18s, transform 0.18s;
-    display: flex;
-}
-
-.hero-social-link:hover {
-    color: var(--android-green);
-    transform: translateY(-2px);
-}
-
-.hero-social-link svg {
-    width: 22px;
-    height: 22px;
-    fill: currentColor;
-}
-
-/* ── Home post cards ────────────────────────────────── */
-
-.home-posts {
-    margin-top: 4px;
-}
-
-.home-posts-title {
-    font-size: 0.78rem;
-    font-weight: 600;
-    text-transform: uppercase;
+.term-panel-title {
+    position: absolute;
+    top: -0.58em;
+    left: 12px;
+    background: var(--t-panel);
+    padding: 0 7px;
+    font-size: 0.70rem;
+    font-weight: 700;
+    color: var(--t-green);
     letter-spacing: 0.12em;
-    color: var(--secondary);
-    margin-bottom: 14px;
+    text-transform: lowercase;
+    line-height: 1;
+    user-select: none;
 }
 
-.accent-slash {
-    color: var(--android-green);
-    margin-right: 6px;
-    font-weight: 700;
+/* ── Hero section ───────────────────────────────────────── */
+
+.term-hero {
+    padding: 28px 0 20px;
 }
 
-.home-card {
-    position: relative;
-    background: var(--entry);
-    border: 1px solid var(--border);
-    border-left: 3px solid var(--android-green);
-    border-radius: 10px;
-    margin-bottom: 10px;
-    transition: border-color 0.2s, transform 0.18s, box-shadow 0.2s;
-    overflow: hidden;
-}
-
-.home-card:hover {
-    border-color: rgba(61, 220, 132, 0.35);
-    border-left-color: var(--android-green);
-    box-shadow: 0 4px 24px rgba(61, 220, 132, 0.07);
-    transform: translateX(4px);
-}
-
-.home-card-inner {
+.term-hero-body {
     display: flex;
-    align-items: center;
-    padding: 18px 20px;
-    gap: 16px;
+    gap: 24px;
+    align-items: flex-start;
 }
 
-.home-card-body {
+.term-avatar {
+    width: 84px;
+    height: 84px;
+    border-radius: var(--radius);
+    object-fit: cover;
+    border: 1px solid var(--t-border-dim);
+    flex-shrink: 0;
+    filter: saturate(0.75) contrast(1.05);
+    transition: border-color 0.2s, filter 0.2s;
+}
+
+.term-panel:hover .term-avatar {
+    border-color: rgba(0, 229, 160, 0.4);
+    filter: saturate(1) contrast(1);
+}
+
+.term-info {
     flex: 1;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
-.home-card-title {
-    font-size: 0.97rem;
-    font-weight: 500;
-    color: var(--primary);
-    margin: 0 0 5px;
-    line-height: 1.4;
-    transition: color 0.18s;
-    white-space: nowrap;
+/* key : value rows */
+.term-kv {
+    display: flex;
+    align-items: baseline;
+    font-size: 0.83rem;
+    line-height: 1.55;
+}
+
+.term-k {
+    color: var(--t-muted);
+    min-width: 56px;
+    text-align: right;
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+}
+
+.term-sep {
+    color: var(--t-sep);
+    padding: 0 10px 0 8px;
+    flex-shrink: 0;
+    user-select: none;
+}
+
+.term-v {
+    color: var(--t-text);
+    flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.home-card:hover .home-card-title {
-    color: var(--android-green);
+.term-v-accent { color: var(--t-green); }
+
+.term-v-link {
+    color: var(--t-text-dim) !important;
+    text-decoration: none !important;
+    border-bottom: 1px solid var(--t-sep);
+    transition: color 0.15s, border-color 0.15s;
 }
 
-.home-card-meta {
-    font-size: 0.78rem;
-    color: var(--secondary);
+.term-v-link:hover {
+    color: var(--t-green) !important;
+    border-bottom-color: var(--t-green);
 }
 
-.home-card-arrow {
-    color: var(--tertiary);
-    flex-shrink: 0;
-    transition: color 0.18s, transform 0.18s;
+/* ── Hero action buttons ────────────────────────────────── */
+
+.term-hero-actions {
     display: flex;
+    gap: 10px;
+    margin-top: 14px;
+    flex-wrap: wrap;
+    padding-left: 74px; /* align under the info, past the key column */
 }
 
-.home-card:hover .home-card-arrow {
-    color: var(--android-green);
-    transform: translateX(3px);
+.term-btn {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 0.78rem;
+    color: var(--t-green) !important;
+    text-decoration: none !important;
+    border: 1px solid rgba(0, 229, 160, 0.28);
+    padding: 5px 16px;
+    border-radius: var(--radius);
+    background: transparent;
+    transition: background 0.15s, border-color 0.15s;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
 }
 
-.home-card-link {
+.term-btn:hover {
+    background: var(--t-green-dim);
+    border-color: var(--t-green);
+}
+
+.term-btn-primary {
+    background: rgba(0, 229, 160, 0.10);
+    border-color: rgba(0, 229, 160, 0.45);
+}
+
+/* ── Social bar ─────────────────────────────────────────── */
+
+.term-social-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    align-items: center;
+    font-size: 0.73rem;
+    border-top: 1px solid var(--t-border-faint);
+    padding-top: 14px;
+    margin-top: 16px;
+}
+
+.term-social-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--t-muted);
+}
+
+.term-social-item .term-social-key {
+    color: var(--t-muted);
+    letter-spacing: 0.06em;
+    user-select: none;
+}
+
+.term-social-item .term-social-dash {
+    color: var(--t-sep);
+    user-select: none;
+}
+
+.term-social-item a {
+    color: var(--t-text-dim) !important;
+    text-decoration: none !important;
+    transition: color 0.15s;
+}
+
+.term-social-item a:hover {
+    color: var(--t-green) !important;
+}
+
+/* ── Posts section ──────────────────────────────────────── */
+
+.term-posts {
+    margin-top: 16px;
+}
+
+.term-posts-inner {
+    padding: 4px 0;
+}
+
+.term-post-row {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 6px;
+    border-radius: var(--radius);
+    border-left: 2px solid transparent;
+    transition: background 0.15s, border-color 0.15s;
+    cursor: pointer;
+}
+
+.term-post-row:hover {
+    background: var(--t-green-dim);
+    border-left-color: var(--t-green);
+}
+
+.term-post-row + .term-post-row {
+    border-top: 1px solid var(--t-border-faint);
+}
+
+.term-post-bullet {
+    font-size: 0.6rem;
+    color: var(--t-muted);
+    flex-shrink: 0;
+    transition: color 0.15s;
+    user-select: none;
+}
+
+.term-post-row:hover .term-post-bullet {
+    color: var(--t-green);
+}
+
+.term-post-title {
+    flex: 1;
+    font-size: 0.85rem;
+    color: var(--t-text-dim);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: color 0.15s;
+}
+
+.term-post-row:hover .term-post-title {
+    color: var(--t-text);
+}
+
+.term-post-date {
+    font-size: 0.70rem;
+    color: var(--t-muted);
+    flex-shrink: 0;
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+}
+
+.term-post-link {
     position: absolute;
     inset: 0;
 }
 
-/* ── Header nav tweaks ──────────────────────────────── */
+/* ── Blog list page (non-home) ──────────────────────────── */
 
-.nav {
-    border-bottom: 1px solid var(--border);
+.post-entry {
+    border: 1px solid var(--t-border-dim) !important;
+    background: var(--t-panel) !important;
+    border-left: 2px solid var(--t-green) !important;
+    border-radius: var(--radius) !important;
+    transition: background 0.15s, border-color 0.15s !important;
 }
 
-/* ── Code blocks ────────────────────────────────────── */
+.post-entry:hover {
+    background: var(--t-panel-alt) !important;
+    border-color: rgba(0, 229, 160, 0.4) !important;
+    border-left-color: var(--t-green) !important;
+    transform: none;
+}
+
+.entry-header h3 {
+    color: var(--t-text);
+}
+
+.post-entry:hover .entry-header h3 {
+    color: var(--t-green);
+}
+
+/* ── Post single page ───────────────────────────────────── */
+
+.post-title {
+    color: var(--t-text);
+}
+
+.post-content a {
+    color: var(--t-green) !important;
+    box-shadow: 0 1px 0 var(--t-border-dim) !important;
+}
+
+.post-content a:hover {
+    box-shadow: 0 1px 0 var(--t-green) !important;
+}
+
+.post-content blockquote {
+    border-inline-start-color: var(--t-green) !important;
+    color: var(--t-text-dim);
+}
+
+.toc {
+    border-color: var(--t-border-dim) !important;
+    background: var(--t-panel) !important;
+}
+
+.toc a:hover {
+    color: var(--t-green) !important;
+}
+
+/* ── Post tags ──────────────────────────────────────────── */
+
+.post-tags a {
+    background: var(--t-panel) !important;
+    border: 1px solid var(--t-border-dim);
+    color: var(--t-muted) !important;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    border-radius: var(--radius) !important;
+    transition: all 0.15s;
+}
+
+.post-tags a:hover,
+.paginav a:hover {
+    background: var(--t-green-dim) !important;
+    border-color: var(--t-green) !important;
+    color: var(--t-green) !important;
+}
+
+/* ── Code / Highlight ───────────────────────────────────── */
 
 .highlight {
-    border-radius: 10px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--t-border-dim);
+    border-radius: var(--radius);
     overflow: hidden;
 }
 
-/* ── Post page links ────────────────────────────────── */
-
-.post-single .post-content a {
-    color: var(--android-green);
+/* inline code */
+.post-content code {
+    background: var(--t-panel) !important;
+    color: var(--t-green-lit);
+    border: 1px solid var(--t-border-faint);
 }
 
-/* ── Responsive ─────────────────────────────────────── */
+/* ── Share / pagination ─────────────────────────────────── */
+
+.paginav a {
+    color: var(--t-green) !important;
+}
+
+.pagination a {
+    color: var(--t-green) !important;
+}
+
+/* ── Page header (blog list) ────────────────────────────── */
+
+.page-header h1 {
+    color: var(--t-green);
+    font-size: 1.1rem;
+    letter-spacing: 0.06em;
+    text-transform: lowercase;
+}
+
+/* ── Responsive ─────────────────────────────────────────── */
 
 @media (max-width: 600px) {
-    .android-hero {
-        padding: 36px 16px 28px;
+    .term-hero {
+        padding: 20px 0 16px;
     }
 
-    .hero-name {
-        font-size: 1.6rem;
-    }
-
-    .hero-avatar {
-        width: 90px;
-        height: 90px;
-    }
-
-    .hero-avatar-wrap {
-        width: 90px;
-        height: 90px;
-    }
-
-    .hero-actions {
+    .term-hero-body {
         flex-direction: column;
         align-items: center;
+        gap: 16px;
     }
 
-    .hero-btn {
-        width: 180px;
-        justify-content: center;
+    .term-avatar {
+        width: 72px;
+        height: 72px;
     }
 
-    .home-card-title {
+    .term-info {
+        width: 100%;
+    }
+
+    .term-k {
+        text-align: left;
+        min-width: 46px;
+    }
+
+    .term-hero-actions {
+        padding-left: 0;
+        justify-content: flex-start;
+    }
+
+    .term-post-title {
         white-space: normal;
+    }
+
+    .logo a {
+        font-size: 0.78rem;
     }
 }

--- a/assets/css/extended/myfont.css
+++ b/assets/css/extended/myfont.css
@@ -1,10 +1,5 @@
 body {
-  font-family: "Roboto";
-  font-optical-sizing: auto;
-  font-style: normal;
-  font-variation-settings:
-    "wdth" 100,
-    "GRAD" 0;
+  font-family: "JetBrains Mono", monospace;
 }
 
 .giscus-frame {

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,7 +51,7 @@ params:
     safari_pinned_tab: "<link / abs url>"
 
   label:
-    text: "Anik Raj C"
+    text: "anikrajc@anik.sh"
 
   homeInfoParams:
     Title: Hi there wave

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,33 +1,84 @@
 {{- define "main" }}
 
 {{- if .IsHome }}
-<div class="android-hero">
-  <div class="hero-inner">
-    <div class="hero-avatar-wrap">
-      <img src="/dp.webp" alt="{{ site.Title }}" class="hero-avatar" width="104" height="104">
+<div class="term-hero">
+
+  {{/* ── Profile panel ── */}}
+  <div class="term-panel">
+    <span class="term-panel-title">profile</span>
+
+    <div class="term-hero-body">
+      <img src="/dp.webp" alt="{{ site.Title }}" class="term-avatar" width="84" height="84">
+
+      <div class="term-info">
+        <div class="term-kv">
+          <span class="term-k">user</span>
+          <span class="term-sep">:</span>
+          <span class="term-v">Anik Raj C</span>
+        </div>
+        <div class="term-kv">
+          <span class="term-k">role</span>
+          <span class="term-sep">:</span>
+          <span class="term-v">
+            <span class="term-v-accent">android</span>
+            &nbsp;@&nbsp;
+            <a href="https://www.swiggy.com/" class="term-v-link" target="_blank" rel="noopener noreferrer">swiggy</a>
+          </span>
+        </div>
+        <div class="term-kv">
+          <span class="term-k">focus</span>
+          <span class="term-sep">:</span>
+          <span class="term-v">mobile engineering, kotlin, testing</span>
+        </div>
+      </div>
     </div>
-    <h1 class="hero-name">{{ site.Title }}</h1>
-    <p class="hero-role">
-      <span class="hero-role-label">Android</span>
-      <span class="hero-role-sep"> @ </span>
-      <a href="https://www.swiggy.com/" class="hero-company" target="_blank" rel="noopener noreferrer">Swiggy</a>
-    </p>
-    <p class="hero-bio">Building scalable Android apps that deliver food to millions. Writing about mobile engineering, testing &amp; Kotlin.</p>
-    <div class="hero-actions">
-      <a href="/blog/" class="hero-btn hero-btn-primary">Read Blog</a>
-      <a href="https://github.com/anikrajc" class="hero-btn hero-btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+
+    <div class="term-hero-actions">
+      <a href="/blog/" class="term-btn term-btn-primary">[ blog ]</a>
+      <a href="https://github.com/anikrajc" class="term-btn" target="_blank" rel="noopener noreferrer">[ github ]</a>
     </div>
-    <div class="hero-socials">
+
+    <div class="term-social-bar">
       {{- range site.Params.socialIcons }}
-      <a href="{{ .url | safeURL }}" title="{{ .name | title }}" target="_blank" rel="noopener noreferrer me" class="hero-social-link">
-        {{- partial "svg.html" . }}
-      </a>
+      {{- $label := .name | lower }}
+      {{- if eq $label "x" }}{{- $label = "tw" }}{{- end }}
+      {{- if eq $label "linkedin" }}{{- $label = "in" }}{{- end }}
+      {{- if eq $label "github" }}{{- $label = "gh" }}{{- end }}
+      <span class="term-social-item">
+        <span class="term-social-key">{{ $label }}</span>
+        <span class="term-social-dash">─</span>
+        <a href="{{ .url | safeURL }}" target="_blank" rel="noopener noreferrer me">{{ .url | replaceRE `https?://(www\.)?` `` | replaceRE `/$` `` }}</a>
+      </span>
       {{- end }}
     </div>
   </div>
+
+  {{/* ── Posts panel ── */}}
+  {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+  {{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true" }}
+  {{- if gt (len $pages) 0 }}
+  <div class="term-panel term-posts" style="margin-top: 16px;">
+    <span class="term-panel-title">recent posts</span>
+    <div class="term-posts-inner">
+      {{- range $pages }}
+      <div class="term-post-row">
+        <span class="term-post-bullet">▶</span>
+        <span class="term-post-title">
+          {{- .Title }}
+          {{- if .Draft }}&nbsp;<span style="color:var(--t-muted);font-size:0.65rem;">[draft]</span>{{- end }}
+        </span>
+        <span class="term-post-date">{{ .Date.Format "Jan 2006" }}</span>
+        <a class="term-post-link" aria-label="{{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+      </div>
+      {{- end }}
+    </div>
+  </div>
+  {{- end }}
+
 </div>
 {{- end }}
 
+{{/* ── Non-home: blog list page ── */}}
 {{- if not .IsHome | and .Title }}
 <header class="page-header">
   {{- partial "breadcrumbs.html" . }}
@@ -60,48 +111,12 @@
 </div>
 {{- end }}
 
+{{- if not .IsHome }}
 {{- $pages := union .RegularPages .Sections }}
-{{- if .IsHome }}
-{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
-{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true" }}
-{{- end }}
-
 {{- $paginator := .Paginate $pages }}
-
-{{- if and .IsHome (gt (len $paginator.Pages) 0) }}
-<div class="home-posts">
-  <h2 class="home-posts-title"><span class="accent-slash">//</span> Recent Posts</h2>
-{{- end }}
-
 {{- $term := .Data.Term }}
+
 {{- range $index, $page := $paginator.Pages }}
-
-{{- if $.IsHome }}
-<article class="home-card">
-  <div class="home-card-inner">
-    <div class="home-card-body">
-      <h3 class="home-card-title">
-        {{- $page.Title }}
-        {{- if $page.Draft }}
-        <span class="entry-hint" title="Draft">
-          <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 -960 960 960" fill="currentColor"><path d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z"/></svg>
-        </span>
-        {{- end }}
-      </h3>
-      {{- if not ($page.Param "hideMeta") }}
-      <div class="home-card-meta">{{- partial "post_meta.html" $page -}}</div>
-      {{- end }}
-    </div>
-    <div class="home-card-arrow">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M5 12h14M12 5l7 7-7 7"/>
-      </svg>
-    </div>
-  </div>
-  <a class="home-card-link" aria-label="post link to {{ $page.Title | plainify }}" href="{{ $page.Permalink }}"></a>
-</article>
-{{- else }}
-
 {{- $class := "post-entry" }}
 {{- if $term }}{{- $class = "post-entry tag-entry" }}{{- end }}
 
@@ -131,11 +146,6 @@
   </div>
 </article>
 {{- end }}
-{{- end }}
-
-{{- if and .IsHome (gt (len $paginator.Pages) 0) }}
-</div>
-{{- end }}
 
 {{- if gt $paginator.TotalPages 1 }}
 <footer class="page-footer">
@@ -159,5 +169,7 @@
   </nav>
 </footer>
 {{- end }}
+
+{{- end }}{{/* end non-home */}}
 
 {{- end }}{{- /* end main */ -}}


### PR DESCRIPTION
Full terminal retheme inspired by the btop system monitor.

**Visual design:**
- JetBrains Mono everywhere — full monospace aesthetic
- Header logo becomes `$ anikrajc@anik.sh` with muted prompt prefix; menu items styled as `[ blog ]`
- Deep terminal palette: `#0A0A0A` background, `#0D1710` panel surface, `#00E5A0` teal-green (btop's exact border color) for all accents

**Home page:**
- Two stacked btop-style panels with floating title chips in the border
- Profile panel: avatar + key:value rows (`user`, `role`, `focus`) + `[ blog ]` / `[ github ]` buttons + social bar
- Posts panel: `▶` bullet list with post title and compact date; left green border + bullet color change on hover

**Rest of site:**
- Blog list cards get left green border
- Post content links, blockquotes, tags, inline code all follow the terminal palette
- All borders use btop's `rgba(0,229,160,…)` teal green

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_