### PR TITLE
Restore dollar sign prefix on header logo

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -63,6 +63,12 @@ html, body {
     text-decoration: none !important;
 }
 
+.logo a::before {
+    content: "$ ";
+    color: var(--t-muted);
+    font-weight: 400;
+}
+
 #menu li a {
     color: var(--t-muted) !important;
     font-size: 0.8rem;


### PR DESCRIPTION
Adds back the muted `$ ` prefix before `./anik.sh` in the header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_