### PR TITLE
Remove profile image from home page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,8 +8,6 @@
     <span class="term-panel-title">profile</span>
 
     <div class="term-hero-body">
-      <img src="/dp.webp" alt="{{ site.Title }}" class="term-avatar" width="84" height="84">
-
       <div class="term-info">
         <div class="term-kv">
           <span class="term-k">user</span>


### PR DESCRIPTION
Removes the avatar image from the profile panel on the home page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_