### PR TITLE
Fix terminal theme not applying on blog/post pages

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -31,7 +31,9 @@
     --radius:        2px;
 }
 
-:root[data-theme="dark"] {
+/* PaperMod applies dark mode via body.dark — override here so all pages match */
+body.dark,
+body[data-theme="dark"] {
     --theme:         #0A0A0A;
     --entry:         #0D1710;
     --primary:       #DDEEDD;


### PR DESCRIPTION
PaperMod applies dark mode by adding `body.dark` class, not via `[data-theme="dark"]` attribute. The CSS variable overrides were using the wrong selector so they never matched on the blog listing or post pages — those pages fell back to PaperMod's default dark palette instead of the terminal theme.

Fix: change the selector to `body.dark, body[data-theme="dark"]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_