### PR TITLE
Switch body font to Inter; keep mono for terminal UI and code

### DIFF
--- a/assets/css/extended/myfont.css
+++ b/assets/css/extended/myfont.css
@@ -1,4 +1,15 @@
 body {
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+/* Keep terminal UI and code in monospace */
+code,
+pre,
+kbd,
+.logo a,
+#menu li a,
+.term-panel,
+.term-panel * {
   font-family: "JetBrains Mono", monospace;
 }
 

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,5 +1,5 @@
 <link
-    href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
     rel="stylesheet">
 
 <script src="https://unpkg.com/kotlin-playground@1" data-selector=".kotlin-code"></script>


### PR DESCRIPTION
- Body font switched from JetBrains Mono → **Inter** (much better for reading long-form content)
- JetBrains Mono retained for: header logo, nav menu, all `.term-panel` elements (home page terminal UI), `code`/`pre`/`kbd` blocks
- Roboto removed from Google Fonts (unused since the terminal retheme)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJn3YyyqNhubstusUkiFUr)_