### PR TITLE
Reduce desktop toolbar height from 60px to 44px

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -58,6 +58,15 @@ html, body {
     border-bottom: 1px solid var(--t-border-dim) !important;
 }
 
+@media (min-width: 769px) {
+    :root { --header-height: 44px; }
+    .nav {
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: var(--header-height);
+    }
+}
+
 .logo a {
     color: var(--t-green) !important;
     font-weight: 700;


### PR DESCRIPTION
Overrides PaperMod's `--header-height` variable (60px → 44px) and removes the nav's vertical padding on desktop only (min-width 769px).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEdJyuVsqwBEkX6bkfgQa)_