### PR TITLE
Revert header height; reduce logo font size to 0.82rem

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -58,17 +58,9 @@ html, body {
     border-bottom: 1px solid var(--t-border-dim) !important;
 }
 
-@media (min-width: 769px) {
-    :root { --header-height: 44px; }
-    .nav {
-        padding-top: 0;
-        padding-bottom: 0;
-        line-height: var(--header-height);
-    }
-}
-
 .logo a {
     color: var(--t-green) !important;
+    font-size: 0.82rem;
     font-weight: 700;
     letter-spacing: -0.01em;
     text-decoration: none !important;


### PR DESCRIPTION
Reverts the toolbar height override and reduces the `./anik.sh` logo text from PaperMod's default (~1rem) to 0.82rem across all pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEdJyuVsqwBEkX6bkfgQa)_