### PR TITLE
Set header height to 50px across all pages

### DIFF
--- a/assets/css/extended/android-theme.css
+++ b/assets/css/extended/android-theme.css
@@ -53,9 +53,17 @@ html, body {
 
 /* ── Header ─────────────────────────────────────────────── */
 
+:root { --header-height: 50px; }
+
 .header {
     background: var(--t-bg) !important;
     border-bottom: 1px solid var(--t-border-dim) !important;
+}
+
+.nav {
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: var(--header-height);
 }
 
 .logo a {


### PR DESCRIPTION
Overrides PaperMod's `--header-height` from 60px to 50px and zeroes out the nav's vertical padding, applying to all screen sizes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDEdJyuVsqwBEkX6bkfgQa)_